### PR TITLE
Update ContactTable.class.php

### DIFF
--- a/lib/model/doctrine/ContactTable.class.php
+++ b/lib/model/doctrine/ContactTable.class.php
@@ -339,7 +339,6 @@ class ContactTable extends Doctrine_Table {
         $personal_salutation = $i18n->__('Dear Sir %F %L,', array('%F' => $contact['firstname'], '%L' => $contact['lastname']));
       else
         $personal_salutation = $i18n->__('Dear Sir/Madam %F %L,', array('%F' => $contact['firstname'], '%L' => $contact['lastname']));
-      $personal_salutation .= "\n\n";
       if (in_array(PetitionTable::KEYWORD_PERSONAL_SALUTATION, $slected_keywords)) {
         $subst[PetitionTable::KEYWORD_PERSONAL_SALUTATION] = $personal_salutation;
       }


### PR DESCRIPTION
Remove the two newlines added as part of the #PERSONAL-SALUTATION# keyword substitution as they lead to unexpected additional line breaks.

For example, I might have the following in the email template:
```
#PERSONAL-SALUTATION#

lorem ipsum dolor sit amet ...
```

Which I expect to get replaced by

```
Sehr geehrter Herr Max Mustermann,

lorem ipsum dolor sit amet ...
```

Instead, it currently gets replaced by

```
Sehr geehrter Herr Max Mustermann,



lorem ipsum dolor sit amet ...
```

Which means that in order to get a correct result, I currently have to write the following email template, which looks confusing to the user:
```
#PERSONAL-SALUTATION#lorem ipsum dolor sit amet ...
```