### PR TITLE
fix truncated query strings in ref URLs

### DIFF
--- a/web/js/policat_widget.js
+++ b/web/js/policat_widget.js
@@ -1104,7 +1104,7 @@ $(document).ready(function($) {
 								refName = 'widget[ref]';
 								break;
 						}
-						$.post(window.location.href.split('#', 1)[0], form.serialize() + '&' + refName + '=' + ref, function(data) {
+						$.post(window.location.href.split('#', 1)[0], form.serialize() + '&' + refName + '=' + encodeURIComponent(ref), function(data) {
 							switch (formId) {
 								case 'sign':
 									window.parent.postMessage('policat_signed;' + JSON.stringify({iframe: iframe_no, widget: widget_id}) , '*');


### PR DESCRIPTION
When the widget is embedded on a URL containing a query string such as https://example.com/path?foo=1&bar=2, the widget[ref] parameter that gets sent on form submission and saved as "ref" in the database is truncated before the first "=" character. That means it gets stored as https://example.com/path?foo

I think that wrapping the URL string in encodeURIComponent() before appending it to the serialized form should fix the issue.