### PR TITLE
Fix render-blocking widget script

### DIFF
--- a/apps/frontend/modules/d_widget/templates/_view.php
+++ b/apps/frontend/modules/d_widget/templates/_view.php
@@ -8,8 +8,11 @@
                 </button>
             </div>
             <div class="modal-body">
-                <p><b>HTML-Code:</b><code> &lt;script type="text/javascript"
-                    src="<?php echo url_for('api_js_widget', array('id' => $id), true) ?>"&gt;&lt;/script&gt;</code></p>
+                <p><b>HTML-Code:</b><code> &lt;div id="policat_<?php echo $id ?>"&gt;&lt;div class="policat-loading"&gt;&lt;/div&gt;&lt;/div&gt;
+                        &lt;script type="text/javascript"&gt;window.policat_target_id_<?php echo $id ?> = "policat_<?php echo $id ?>";&lt;/script&gt;
+                        &lt;script type="text/javascript" src="<?php echo url_for('api_js_widget', array('id' => $id), true) ?>" async="true"&gt;&lt;/script&gt;
+                        &lt;style&gt;.policat-loading{position:relative;height:1em;text-align:center}@keyframes policatspin{to{transform:rotate(360deg)}}
+                        .policat-loading::after{content:'';box-sizing:border-box;position:absolute;top:0.33em;width:1em;height:1em;margin-left:1em;border-radius:50%;border-top:2px solid #333;border-right:2px solid transparent;animation:policatspin 0.8s linear infinite}&lt;/style&gt;</code></p>
                 <p><b>Shareable widget page for testing or standalone use (without embedding):</b> <a target="_blank" href="<?php echo url_for('widget_page', ['id' => $id], true) ?>"><?php echo url_for('widget_page', ['id' => $id], true) ?></a></p>
                 <?php if ($follows): ?>
                 <p><strong style="color:red">Attention: The action is following the action


### PR DESCRIPTION
The widget embed code prevents the embedding page from rendering while the widget script is loading. Instead, the script can be loaded asyncronously while showing a loading animation.

An example of an asynchronous embed code that loads widget 9123 from policat.org:

```html
<div id="policat_9123"><div class="policat-loading"></div></div>
<script type="text/javascript">window.policat_target_id_9123 = "policat_9123";</script>
<script type="text/javascript" src="https://www.policat.org/api/js/widget/9123" async="true"></script>
<style>
.policat-loading {
    position: relative;
    height: 1em;
    text-align: center;
}
@keyframes policatspin {
  to {transform: rotate(360deg);}
}
.policat-loading::after {
    content: '';
    box-sizing: border-box;
    position: absolute;
    top: .33em;
    width: 1em;
    height: 1em;
    margin-left: 1em;
    border-radius: 50%;
    border-top: 2px solid #333;
    border-right: 2px solid transparent;
    animation: policatspin .8s linear infinite;
}
</style>
```